### PR TITLE
Add rpm building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - icnsutils
       - graphicsmagick
       - xz-utils
+      - rpm
 
 # Handle git submodules yourself 
 git:

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -38,7 +38,8 @@
     "maintainer": "JGraph <support@draw.io>",
     "target": [
       "AppImage",
-      "deb"
+      "deb",
+      "rpm"
     ]
   }
 }


### PR DESCRIPTION
Since there are various linux distros that are not using the .deb format, it would be nice to provide a rpm package for them. This is done by this change and allows Fedora users to enjoy the awesome drawio-desktop client 😄