### PR TITLE
Removed dor from directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Setup:
 
 To run this:
 1. npm install (in the root directory of this repo)
-2. npm install (in the draw.io directory of this repo)
+2. npm install (in the drawio directory of this repo)
 2. export NODE_ENV=development
 3. npm start
 


### PR DESCRIPTION
Small typo fix drawio directory name had changed but readme did not reflect the change