### PR TITLE
Added png filetype

### DIFF
--- a/electron-builder-linux-mac.json
+++ b/electron-builder-linux-mac.json
@@ -63,6 +63,13 @@
 	  	"description": "VSDX Document",
 	  	"mimeType": "application/vnd.visio",
 	  	"role": "Editor"
+	  },
+	  {
+	  	"ext": "png",
+	  	"name": "draw.io Diagram",
+	  	"description": "draw.io Diagram embedded in PNG",
+	  	"mimeType": "image/png",
+	  	"role": "Editor"
 	  }
   ]
 }


### PR DESCRIPTION
Added PNG filetype to the mac/linux electron builder.

Would potentially close #791 