### PR TITLE
Do not package build-id metadata for RPM target

### DIFF
--- a/electron-builder-linux-mac.json
+++ b/electron-builder-linux-mac.json
@@ -58,6 +58,11 @@
           "arm64"
         ]
       }
+    ],
+  },
+  "rpm": {
+    "fpm": [
+      "--rpm-rpmbuild-define=_build_id_links none"
     ]
   },
   "fileAssociations": [


### PR DESCRIPTION
Fix inspired by mullvad/mullvadvpn-app#4547 

fixes #259