### PR TITLE
Add PNG file association

### DIFF
--- a/electron-builder-linux-mac.json
+++ b/electron-builder-linux-mac.json
@@ -80,6 +80,13 @@
 	  	"description": "VSDX Document",
 	  	"mimeType": "application/vnd.visio",
 	  	"role": "Editor"
-	  }
+	  },
+	  {
+	  	"ext": "png",
+	  	"name": "Portable Network Graphics Image",
+	  	"description": "Portable Network Graphics Image",
+	  	"mimeType": "image/png",
+	  	"role": "Editor"
+	  } 
   ]
 }


### PR DESCRIPTION
Fix #609 (and #1035). Adds drawio as a valid editor for .png and 'image/png' files on linux and macos.

This initial PR is restricted to solving the bug request. However, I guess it might make sense to extend the file associations to svg, as well as make the changes on other OS.

This PR does have the downside of showing drawio in the list of options for ordinary PNG files. These just open a blank document. However this seems to be a reasonable compromise.