### PR TITLE
Fix missing rendering in headless mode

### DIFF
--- a/src/main/electron.js
+++ b/src/main/electron.js
@@ -1621,7 +1621,8 @@ function exportDiagram(event, args, directFinalize)
 				preload: `${__dirname}/electron-preload.js`,
 				backgroundThrottling: false,
 				contextIsolation: true,
-				disableBlinkFeatures: 'Auxclick' // Is this needed?
+				disableBlinkFeatures: 'Auxclick', // Is this needed?
+				offscreen: true,
 			},
 			show : false,
 			frame: false,


### PR DESCRIPTION
Fixes #2190

I have looked at the exporting process and realized that `browser.capturePage()` never finishes. I have found out that the reason could be that the page does not render.

A simple change in the browser configuration fixes this behavior, triggering a paint even in headless mode.