### PR TITLE
Fix Ubuntu dock icon not showing correctly

### DIFF
--- a/electron-builder-linux-mac.json
+++ b/electron-builder-linux-mac.json
@@ -43,6 +43,9 @@
     "category": "Graphics",
     "maintainer": "JGraph <support@draw.io>",
     "icon": "./build",
+    "desktop": {
+      "StartupWMClass": "draw.io"
+    },
     "target": [
       { "target": "AppImage", "arch": [
           "x64",

--- a/electron-builder-snap.json
+++ b/electron-builder-snap.json
@@ -16,6 +16,9 @@
     "category": "Graphics",
     "maintainer": "draw.io <snap@draw.io>",
     "icon": "./build",
+    "desktop": {
+      "StartupWMClass": "draw.io"
+    },
     "target": [
       "snap"
     ]


### PR DESCRIPTION
## Summary
This PR fixes the Ubuntu dock icon showing as a gear icon instead of the draw.io icon on Ubuntu 24.04.

## Problem
The `.desktop` file generated by electron-builder sets `StartupWMClass=drawio`, but the application actually uses `draw.io` as its WM class. This mismatch causes the dock to not recognize the running application and display a generic gear icon.

## Solution
Added `desktop.StartupWMClass` configuration to the Linux build configs:
- `electron-builder-linux-mac.json` (for deb, rpm, AppImage)
- `electron-builder-snap.json` (for Snap)

This sets `StartupWMClass=draw.io` to match the actual WM class used by the application.

## Testing
After this change, the `.desktop` file will contain:
```
StartupWMClass=draw.io
```

Which matches the output of:
```sh
$ xprop | grep WM_CLASS
WM_CLASS(STRING) = "draw.io", "draw.io"
```

Fixes #1745