### PR TITLE
Cache autoupdate check to run only once per 24 hours

### DIFF
--- a/src/main/electron.js
+++ b/src/main/electron.js
@@ -1171,8 +1171,10 @@ app.whenReady().then(() =>
 		owner: 'jgraph'
 	})
 	
-	// Cache update check - only check once per 24 hours to avoid repeated messages
-	const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+	// Cache update check - configurable interval (default: 24 hours)
+	const DEFAULT_UPDATE_CHECK_HOURS = 24;
+	const updateCheckHours = store?.get('updateCheckIntervalHours') ?? DEFAULT_UPDATE_CHECK_HOURS;
+	const UPDATE_CHECK_INTERVAL = updateCheckHours * 60 * 60 * 1000;
 	const lastUpdateCheck = store?.get('lastUpdateCheck') || 0;
 	const shouldCheckUpdates = Date.now() - lastUpdateCheck > UPDATE_CHECK_INTERVAL;
 	

--- a/src/main/electron.js
+++ b/src/main/electron.js
@@ -1171,8 +1171,18 @@ app.whenReady().then(() =>
 		owner: 'jgraph'
 	})
 	
-	if (store == null || (!disableUpdate && !store.get('dontCheckUpdates')))
+	// Cache update check - only check once per 24 hours to avoid repeated messages
+	const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
+	const lastUpdateCheck = store?.get('lastUpdateCheck') || 0;
+	const shouldCheckUpdates = Date.now() - lastUpdateCheck > UPDATE_CHECK_INTERVAL;
+	
+	if (store == null || (!disableUpdate && !store.get('dontCheckUpdates') && shouldCheckUpdates))
 	{
+		if (store != null)
+		{
+			store.set('lastUpdateCheck', Date.now());
+		}
+		
 		autoUpdater.checkForUpdates()
 	}
 })


### PR DESCRIPTION
## Summary
This PR caches the autoupdate check so it only runs once per 24 hours instead of on every application start.

## Problem
When running drawio frequently or in scripts (even with `--help` flag), the autoupdate check runs every time, outputting messages like:
```
Checking for beta autoupdate feature for deb/rpm distributions
Found package-type: deb
```

This is especially annoying when running drawio in a loop or automated scripts.

## Solution
- Store the last update check timestamp in electron-store
- Only perform update check if 24 hours have passed since the last check
- Existing behavior is preserved: users can still manually check for updates via the menu

## Changes
- Modified `src/main/electron.js` to cache update check timestamp

Fixes #2262