### PR TITLE
Add application name to update confirmation dialog

### DIFF
--- a/src/main/electron.js
+++ b/src/main/electron.js
@@ -1303,8 +1303,8 @@ autoUpdater.on('update-available', (a, b) =>
 	{
 		type: 'question',
 		buttons: ['Ok', 'Cancel', 'Don\'t Ask Again'],
-		title: 'Confirm Update',
-		message: 'Update available.\n\nWould you like to download and install new version?',
+		title: 'Confirm draw.io Update',
+		message: 'Update for draw.io available.\n\nWould you like to download and install the new version?',
 		detail: 'Application will automatically restart to apply update after download',
 	}).then( result =>
 	{


### PR DESCRIPTION
## Summary
This PR adds the application name 'draw.io' to the update confirmation dialog to make it clear which application is requesting the update.

## Problem
When the update dialog appears, it shows generic text like 'Update available' without mentioning which application. This can be confusing for users, especially on slower systems where the connection between the dialog and the application startup may not be obvious.

**Before:**
- Title: 'Confirm Update'
- Message: 'Update available...'

**After:**
- Title: 'Confirm draw.io Update'
- Message: 'Update for draw.io available...'

## Changes
- Modified `src/main/electron.js` to include 'draw.io' in the dialog title and message

Fixes #1229